### PR TITLE
rsync can't connect to remote host

### DIFF
--- a/lib/wordmove/hosts/remote_host.rb
+++ b/lib/wordmove/hosts/remote_host.rb
@@ -94,7 +94,8 @@ module Wordmove
 
       arguments = [ "-azLKO" ]
 
-      if options.ssh && (options.ssh.port || options.ssh.password || options.ssh.gateway)
+      # if options.ssh && (options.ssh.port || options.ssh.password || options.ssh.gateway)
+      if options.ssh
 
         remote_shell_arguments = []
 


### PR DESCRIPTION
I need to remove the first check because ssh credentials (username and host) wasn't passed to rsync command.
