### PR TITLE
exclude in skeleton

### DIFF
--- a/lib/wordmove/generators/Movefile
+++ b/lib/wordmove/generators/Movefile
@@ -9,6 +9,11 @@ local:
 staging:
   vhost: "http://remote.com"
   wordpress_path: "/var/www/your_site"
+  exclude:
+    - ".sass-cache"
+    - ".git"
+    - "tmp/*"
+    - "wp-content/*.sql"
   database:
     name: "database_name"
     user: "user"


### PR DESCRIPTION
I think this is useful with some common defaults and because is not documented elsewhere. Fix #31 in upstream
