### PR TITLE
Fix wordmove push --all

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -91,7 +91,7 @@ staging:
 Just not use the `remote.ssh.password` field on your `Movefile`. Easy peasy.
 
 ### If you want to specify SSH password on the Movefile
-Please take a look at the various gotchas of the underlying [`photocopier` gem](https://github.com/stefanoverna/photocopier#password-gotchas).
+Please take a look at the various gotchas of the underlying [`photocopier` gem](https://github.com/welaika/photocopier#password-gotchas).
 
 ### How the heck you are able to sync the DB via FTP?
 We're glad you asked! We basically upload via FTP a PHP script that performs the various

--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -77,24 +77,30 @@ module Wordmove
         end
       end
 
-      def get_options_for_wordpress(type)
-        {
-          :local_path    => local_options[:wordpress_path],
-          :remote_path   => remote_options[:wordpress_path],
-          :exclude_paths => paths_to_exclude.push(send("#{type}_wp_content_dir").relative_path)
-        }
+      def exclude_dir_contents(path)
+        "#{path}/*"
       end
 
       def push_wordpress
         logger.task "Pushing wordpress core"
-        options = get_options_for_wordpress("local")
-        remote_put_directory(options[:local_path], options[:remote_path], options[:exclude_paths])
+
+        local_path = local_options[:wordpress_path]
+        remote_path = remote_options[:wordpress_path]
+        exclude_wp_content = exclude_dir_contents(local_wp_content_dir.relative_path)
+        exclude_paths = paths_to_exclude.push(exclude_wp_content)
+
+        remote_put_directory(local_path, remote_path, exclude_paths)
       end
 
       def pull_wordpress
         logger.task "Pulling wordpress core"
-        options = get_options_for_wordpress("remote")
-        remote_get_directory(options[:remote_path], options[:local_path], options[:exclude_paths])
+
+        local_path = local_options[:wordpress_path]
+        remote_path = remote_options[:wordpress_path]
+        exclude_wp_content = exclude_dir_contents(remote_wp_content_dir.relative_path)
+        exclude_paths = paths_to_exclude.push(exclude_wp_content)
+
+        remote_get_directory(remote_path, local_path, exclude_paths)
       end
 
       protected

--- a/lib/wordmove/version.rb
+++ b/lib/wordmove/version.rb
@@ -1,3 +1,3 @@
 module Wordmove
-  VERSION = "1.0.9"
+  VERSION = "1.0.10"
 end

--- a/wordmove.gemspec
+++ b/wordmove.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "thor"
   gem.add_dependency "activesupport"
   gem.add_dependency "i18n"
-  gem.add_dependency "photocopier", ">= 0.0.6"
+  gem.add_dependency "photocopier", ">= 0.0.7"
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "cucumber"


### PR DESCRIPTION
Ignore only wp-content contents, but keep the folder.
