### PR TITLE
remote.com to example.com

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -59,7 +59,7 @@ local:
     host: "127.0.0.1"
 
 staging:
-  vhost: "http://remote.com"
+  vhost: "http://example.com"
   wordpress_path: "/var/www/your_site" # use an absolute path here
 
   database:

--- a/lib/wordmove/generators/Movefile
+++ b/lib/wordmove/generators/Movefile
@@ -9,7 +9,7 @@ local:
     host: "<%= database.host %>"
 
 staging:
-  vhost: "http://remote.com"
+  vhost: "http://example.com"
   wordpress_path: "/var/www/your_site" # use an absolute path here
 
   database:

--- a/spec/fixtures/Movefile
+++ b/spec/fixtures/Movefile
@@ -7,7 +7,7 @@ local:
     password: "password"
     host: "host"
 remote:
-  vhost: "http://remote.com"
+  vhost: "http://example.com"
   wordpress_path: "/var/www/your_site"
   database:
     name: "database_name"


### PR DESCRIPTION
remote.com is wrong to use example domain name.
