### PR TITLE
sql_adapter.rb:44:in `gsub!': invalid byte sequence in UTF-8 (ArgumentError)

### DIFF
--- a/lib/wordmove/sql_adapter.rb
+++ b/lib/wordmove/sql_adapter.rb
@@ -41,6 +41,9 @@ module Wordmove
     def serialized_replace!(source_field, dest_field)
       length_delta = source_field.length - dest_field.length
 
+      sql_content.encode!('UTF-16', 'UTF-8', :invalid => :replace, :replace => '')
+      sql_content.encode!('UTF-8', 'UTF-16')
+
       sql_content.gsub!(/s:(\d+):([\\]*['"])(.*?)\2;/) do |match|
         length = $1.to_i
         delimiter = $2


### PR DESCRIPTION
In thid problem,
I did not resolved the error by #91.
Maybe, I have not removed the illegal character yet.
So, I removed the illegal character via UTF-16.