### PR TITLE
Added to put ruby code support in Movefile

### DIFF
--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -5,6 +5,7 @@ require 'wordmove/logger'
 require 'wordmove/wordpress_directory'
 require 'wordmove/sql_adapter'
 require 'escape'
+require 'erb'
 require 'yaml'
 
 module Wordmove
@@ -55,7 +56,7 @@ module Wordmove
 
           found = entries.first
           logger.task("Using Movefile: #{found}")
-          YAML::load(File.open(found))
+          YAML::load(ERB.new(File.read(found)).result)
         end
 
         def current_dir

--- a/spec/features/movefile_spec.rb
+++ b/spec/features/movefile_spec.rb
@@ -27,12 +27,12 @@ describe Wordmove::Generators::Movefile do
     end
 
     it 'fills local wordpress_path using shell path' do
-      yaml = YAML::load(File.open(movefile))
+      yaml = YAML::load(ERB.new(File.read(movefile)).result)
       expect(yaml['local']['wordpress_path']).to eq(Dir.pwd)
     end
 
     it 'fills database configuration defaults' do
-      yaml = YAML::load(File.open(movefile))
+      yaml = YAML::load(ERB.new(File.read(movefile)).result)
       expect(yaml['local']['database']['name']).to eq('database_name')
       expect(yaml['local']['database']['user']).to eq('user')
       expect(yaml['local']['database']['password']).to eq('password')
@@ -49,7 +49,7 @@ describe Wordmove::Generators::Movefile do
     end
 
     it 'fills database configuration from wp-config' do
-      yaml = YAML::load(File.open(movefile))
+      yaml = YAML::load(ERB.new(File.read(movefile)).result)
       expect(yaml['local']['database']['name']).to eq('wordmove_db')
       expect(yaml['local']['database']['user']).to eq('wordmove_user')
       expect(yaml['local']['database']['password']).to eq('wordmove_password')


### PR DESCRIPTION
Hi
As it is now, can't load a YAML file containing ERB like a basic YAML file.
So that, I added to put ruby code support in Movefile.