### PR TITLE
Better support during mysql import for large dbs

### DIFF
--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -194,7 +194,7 @@ module Wordmove
         command << "--password=#{Shellwords.escape(options[:password])}" if options[:password].present?
         command << "--default-character-set=#{Shellwords.escape(options[:charset])}" if options[:charset].present?
         command << "--database=#{Shellwords.escape(options[:name])}"
-        command << "--execute=\"SET autocommit=0;SOURCE " + dump_path.gsub("\\","/") + ";COMMIT\""
+        command << "--execute=\"SET autocommit=0;SOURCE #{dump_path};COMMIT\""
         puts command.join(" ")
         command.join(" ")
       end

--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -194,7 +194,7 @@ module Wordmove
         command << "--password=#{Shellwords.escape(options[:password])}" if options[:password].present?
         command << "--default-character-set=#{Shellwords.escape(options[:charset])}" if options[:charset].present?
         command << "--database=#{Shellwords.escape(options[:name])}"
-        command << "--execute=#{Shellwords.escape("SOURCE #{dump_path}")}"
+        command << "--execute=\"SET autocommit=0;SOURCE " + dump_path.gsub("\\","/") + ";COMMIT\""
         puts command.join(" ")
         command.join(" ")
       end

--- a/spec/deployer/base_spec.rb
+++ b/spec/deployer/base_spec.rb
@@ -154,7 +154,7 @@ describe Wordmove::Deployer::Base do
           name: "database_name"
         }
       )
-      expect(command).to eq("mysql --host=localhost --port=8888 --user=root --password=\\'\\\"\\$ciao --default-character-set=utf8 --database=database_name --execute=SOURCE\\ ./my\\ dump.sql")
+      expect(command).to eq("mysql --host=localhost --port=8888 --user=root --password=\\'\\\"\\$ciao --default-character-set=utf8 --database=database_name --execute=\"SET autocommit=0;SOURCE ./my dump.sql;COMMIT\"")
     end
   end
 end


### PR DESCRIPTION
- Set autocommit point to better handle import of large (500MB+) databases
- Don't use shellword escape on the path since it messes up on Windows systems (#247)