### PR TITLE
Fix Mysql charset error

### DIFF
--- a/lib/wordmove/sql_adapter.rb
+++ b/lib/wordmove/sql_adapter.rb
@@ -16,7 +16,14 @@ module Wordmove
     def adapt!
       replace_vhost!
       replace_wordpress_path!
+      replace_charset!
       write_sql!
+    end
+
+    def replace_charset!
+      source_charset = source_config[:database][:charset]
+      dest_charset = dest_config[:database][:charset]
+      replace_field!(source_charset, dest_charset)
     end
 
     def replace_vhost!


### PR DESCRIPTION
A default character code of wordpress was utf8mb4 from version 4.2.
However, utf8mb4 isn't being supported with the old version of mysql, so it'll be an error.
The problem is settled by the following setting.

```
local:
  database:
    charset: "utf8mb4";
 
staging:
  database:
    charset: "utf8";
```
