### PR TITLE
Windows Fix - Quote result-file in mysqldump

### DIFF
--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -180,7 +180,7 @@ module Wordmove
           command << "--default-character-set=#{Shellwords.escape(options[:charset])}"
         end
         command << Shellwords.escape(options[:name])
-        command << "--result-file=#{Shellwords.escape(save_to_path)}"
+        command << "--result-file=\"#{save_to_path}\""
         puts command.join(" ")
         command.join(" ")
       end

--- a/spec/deployer/base_spec.rb
+++ b/spec/deployer/base_spec.rb
@@ -130,7 +130,7 @@ describe Wordmove::Deployer::Base do
           [
             "mysqldump --host=localhost",
             "--port=8888 --user=root --password=\\'\\\"\\$ciao",
-            "--default-character-set=utf8 database_name --result-file=./mysql\\ dump.sql"
+            "--default-character-set=utf8 database_name --result-file=\"./mysql dump.sql\""
           ].join(' ')
         )
       )


### PR DESCRIPTION
Similar to #253, we need to remove the `Shellwords.escape` command and instead quote the string for proper support for Windows.