### PR TITLE
Rename Path module, this is not a constant it's an inner class, Use s…

### DIFF
--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -147,11 +147,11 @@ module Wordmove
       end
 
       [
-        WordpressDirectory::PATH::WP_CONTENT,
-        WordpressDirectory::PATH::PLUGINS,
-        WordpressDirectory::PATH::THEMES,
-        WordpressDirectory::PATH::UPLOADS,
-        WordpressDirectory::PATH::LANGUAGES
+        WordpressDirectory::Path::WP_CONTENT,
+        WordpressDirectory::Path::PLUGINS,
+        WordpressDirectory::Path::THEMES,
+        WordpressDirectory::Path::UPLOADS,
+        WordpressDirectory::Path::LANGUAGES
       ].each do |type|
         [:remote, :local].each do |location|
           define_method "#{location}_#{type}_dir" do

--- a/lib/wordmove/wordpress_directory.rb
+++ b/lib/wordmove/wordpress_directory.rb
@@ -1,20 +1,20 @@
-WordpressDirectory = Struct.new(:type, :options) do
-  module PATH
-    WP_CONTENT = :wp_content
-    WP_CONFIG  = :wp_config
-    PLUGINS    = :plugins
-    THEMES     = :themes
-    UPLOADS    = :uploads
-    LANGUAGES  = :languages
+require 'wordmove/wordpress_directory/path'
+
+class WordpressDirectory
+  attr_accessor :type, :options
+
+  def initialize(type, options)
+    @type = type
+    @options = options
   end
 
   DEFAULT_PATHS = {
-    PATH::WP_CONTENT => 'wp-content',
-    PATH::WP_CONFIG  => 'wp-config.php',
-    PATH::PLUGINS    => 'wp-content/plugins',
-    PATH::THEMES     => 'wp-content/themes',
-    PATH::UPLOADS    => 'wp-content/uploads',
-    PATH::LANGUAGES  => 'wp-content/languages'
+    Path::WP_CONTENT => 'wp-content',
+    Path::WP_CONFIG  => 'wp-config.php',
+    Path::PLUGINS    => 'wp-content/plugins',
+    Path::THEMES     => 'wp-content/themes',
+    Path::UPLOADS    => 'wp-content/uploads',
+    Path::LANGUAGES  => 'wp-content/languages'
   }.freeze
 
   def self.default_path_for(sym)

--- a/lib/wordmove/wordpress_directory/path.rb
+++ b/lib/wordmove/wordpress_directory/path.rb
@@ -1,0 +1,10 @@
+class WordpressDirectory
+  module Path
+    WP_CONTENT = :wp_content
+    WP_CONFIG  = :wp_config
+    PLUGINS    = :plugins
+    THEMES     = :themes
+    UPLOADS    = :uploads
+    LANGUAGES  = :languages
+  end
+end


### PR DESCRIPTION
…tandard class notation to declare WordpressDirectory because inside Wordmove::Deployer::Base the module WordpressDirectory::Path module is referenced directly.

https://github.com/welaika/wordmove/issues/267