### PR TITLE
Crossplatform fixes - shellwords.escape / delete command

### DIFF
--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -207,7 +207,7 @@ module Wordmove
         command = ["gzip"]
         command << "--best"
         command << "--force"
-        command << Shellwords.escape(path)
+        command << "\"#{path}\""
         puts command.join(" ")
         command.join(" ")
       end
@@ -216,13 +216,13 @@ module Wordmove
         command = ["gzip"]
         command << "-d"
         command << "--force"
-        command << Shellwords.escape(path)
+        command << "\"#{path}\""
         puts command.join(" ")
         command.join(" ")
       end
 
       def rm_command(path)
-        "rm #{Shellwords.escape(path)}"
+        File.delete(path)
       end
 
       def save_local_db(local_dump_path)

--- a/spec/deployer/base_spec.rb
+++ b/spec/deployer/base_spec.rb
@@ -139,10 +139,15 @@ describe Wordmove::Deployer::Base do
   end
 
   context "#rm_command" do
+    before do
+      @test_dir = "/tmp/wordmove.delete"
+      FileUtils.mkdir(@test_dir)
+      FileUtils.touch(File.join(@test_dir, "my dump.sql"))
+    end
     let(:deployer) { described_class.new(:dummy_env) }
 
     it "creates a valid shell rm command" do
-      expect(deployer.send(:rm_command, "/var/my dump.sql")).to eq("rm /var/my\\ dump.sql")
+      expect(deployer.send(:rm_command, File.join(@test_dir, "my dump.sql"))).to eq(1)
     end
   end
 
@@ -179,7 +184,7 @@ describe Wordmove::Deployer::Base do
         "dummy file.sql"
       )
 
-      expect(command).to eq("gzip --best --force dummy\\ file.sql")
+      expect(command).to eq("gzip --best --force \"dummy file.sql\"")
     end
   end
 
@@ -192,7 +197,7 @@ describe Wordmove::Deployer::Base do
         "dummy file.sql"
       )
 
-      expect(command).to eq("gzip -d --force dummy\\ file.sql")
+      expect(command).to eq("gzip -d --force \"dummy file.sql\"")
     end
   end
 end


### PR DESCRIPTION
Shellword.escape does not work with Windows paths.  Remove this in the gunzip /gzip commands and wrap with quotes instead.

There is no "rm" command on Windows.  Replace with `File.delete()` which is crossplatform and part of core Ruby.

Update unit tests to match new expected output.