### PR TITLE
Fix php error for date()

### DIFF
--- a/lib/wordmove/assets/dump.php.erb
+++ b/lib/wordmove/assets/dump.php.erb
@@ -95,7 +95,7 @@ class MySQLDump
 		$this->connection->query('LOCK TABLES `' . implode('` READ, `', $tables) . '` READ');
 
 		$db = $this->connection->query('SELECT DATABASE()')->fetch_row();
-		fwrite($handle, "-- Created at " . date('j.n.Y G:i') . " using David Grudl MySQL Dump Utility\n"
+		fwrite($handle, "-- Created at " . @date('j.n.Y G:i') . " using David Grudl MySQL Dump Utility\n"
 			. (isset($_SERVER['HTTP_HOST']) ? "-- Host: $_SERVER[HTTP_HOST]\n" : '')
 			. "-- MySQL Server: " . $this->connection->server_info . "\n"
 			. "-- Database: " . $db[0] . "\n"


### PR DESCRIPTION
When the server has not setted the timezone in php.ini you get a warning about that and the dump not work.
The date is used only to print the data of the day so with @ the error is hidden and the script works without problems.