### PR TITLE
Exclude db-tables from being exported

### DIFF
--- a/lib/wordmove/assets/dump.php.erb
+++ b/lib/wordmove/assets/dump.php.erb
@@ -105,7 +105,10 @@ class MySQLDump
 			. "SET FOREIGN_KEY_CHECKS=0;\n"
 		);
 
+    $exclude = array_map('trim', explode(',', '<%= escape_php db[:exclude] %>'));
 		foreach ($tables as $table) {
+      if(in_array($table, $exclude))
+        continue;
 			$this->dumpTable($handle, $table);
 		}
 

--- a/lib/wordmove/generators/Movefile
+++ b/lib/wordmove/generators/Movefile
@@ -19,6 +19,7 @@ production:
     host: "host"
     # port: "3308" # Use just in case you have exotic server config
     # mysqldump_options: "--max_allowed_packet=1G" # Only available if using SSH
+    # exclude: "table1,table2,table3"
 
   exclude:
     - ".git/"


### PR DESCRIPTION
Add `exclude` option as comma-separated list to Movefile's DB section. Tables will be skipped when creating SQL dumpfile.

Please consider as this is my first ever pull-request
