### PR TITLE
Allow YAML aliases

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -60,7 +60,7 @@ Move inside the Wordpress folder and use `wordmove init` to generate a new `Move
 
 You can configure Wordmove creating a `Movefile`. That's just a YAML file with local and remote host infos:
 
-```
+```yaml
 global:
   sql_adapter: "default"
 

--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -47,7 +47,7 @@ module Wordmove
 
           found = entries.first
           logger.task("Using Movefile: #{found}")
-          YAML.safe_load(ERB.new(File.read(found)).result)
+          YAML.safe_load(ERB.new(File.read(found)).result, [], [], true)
         end
 
         def current_dir


### PR DESCRIPTION
YAML aliases come very handy to avoid some repeating configs blocks in Movefile.

Say you want to share some custom paths because you're using Bedrock:
```yaml
global:
  sql_adapter: "default"

_custom_paths: &custom_paths
  paths:
    wp_content: "../app"
    plugins: "../app/plugins"
    mu_plugins: "../app/mu-plugins"
    uploads: "../app/uploads"
    languages: "../app/languages"
    themes: "../app/themes"

local:
  vhost: "http://vhost.local"
  wordpress_path: "/home/john/sites/your_site" # use an absolute path here

  <<: *custom_paths

  database:
    name: "database_name"
    user: "user"
    password: "password"
    host: "127.0.0.1"

production:
  vhost: "http://example.com"
  wordpress_path: "/var/www/your_site" # use an absolute path here

  <<: *custom_paths

  database:
    name: "database_name"
    user: "user"
    password: "password"
    host: "host"

  ssh:
    host: "host"
    user: "user"
```
