### PR TITLE
fix #477

### DIFF
--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -53,25 +53,6 @@ module Wordmove
 
       def remote_put_directory; end
 
-      %w[uploads themes plugins mu_plugins languages].each do |task|
-        define_method "push_#{task}" do
-          logger.task "Pushing #{task.titleize}"
-          local_path = local_options[:wordpress_path]
-          remote_path = remote_options[:wordpress_path]
-
-          remote_put_directory(local_path, remote_path,
-                               push_exclude_paths, push_inlcude_paths(task))
-        end
-
-        define_method "pull_#{task}" do
-          logger.task "Pulling #{task.titleize}"
-          local_path = local_options[:wordpress_path]
-          remote_path = remote_options[:wordpress_path]
-          remote_get_directory(remote_path, local_path,
-                               pull_exclude_paths, pull_include_paths(task))
-        end
-      end
-
       def exclude_dir_contents(path)
         "#{path}/*"
       end
@@ -204,34 +185,6 @@ module Wordmove
 
       def local_options
         options[:local].clone
-      end
-
-      def push_inlcude_paths(task)
-        [
-          "/#{local_wp_content_dir.relative_path}/",
-          "/#{local_wp_content_dir.relative_path}/#{task}/"
-        ]
-      end
-
-      def push_exclude_paths
-        paths_to_exclude + [
-          "/*",
-          "/#{local_wp_content_dir.relative_path}/*"
-        ]
-      end
-
-      def pull_include_paths(task)
-        [
-          "/#{remote_wp_content_dir.relative_path}/",
-          "/#{remote_wp_content_dir.relative_path}/#{task}/"
-        ]
-      end
-
-      def pull_exclude_paths
-        paths_to_exclude + [
-          "/*",
-          "/#{remote_wp_content_dir.relative_path}/*"
-        ]
       end
     end
   end

--- a/lib/wordmove/deployer/ftp.rb
+++ b/lib/wordmove/deployer/ftp.rb
@@ -58,6 +58,22 @@ module Wordmove
 
       private
 
+      %w[uploads themes plugins mu_plugins languages].each do |task|
+        define_method "push_#{task}" do
+          logger.task "Pushing #{task.titleize}"
+          local_path = send("local_#{task}_dir").path
+          remote_path = send("remote_#{task}_dir").path
+          remote_put_directory(local_path, remote_path, paths_to_exclude)
+        end
+
+        define_method "pull_#{task}" do
+          logger.task "Pulling #{task.titleize}"
+          local_path = send("local_#{task}_dir").path
+          remote_path = send("remote_#{task}_dir").path
+          remote_get_directory(remote_path, local_path, paths_to_exclude)
+        end
+      end
+
       %w[get get_directory put_directory delete].each do |command|
         define_method "remote_#{command}" do |*args|
           logger.task_step false, "#{command}: #{args.join(' ')}"


### PR DESCRIPTION
This was a regression on FTP due to 164206589aa680a1086b3ff9f7af134acbe7dacb

I've moved newer code from Deployer::Base to Deployer::SSH and put "old" code directly into Deployer::FTP. This way we have decoupled even more the two protocols and we should be free to continue improving SSH.

As a side note Deployer and child classes really need some refactor: they are getting a mess the more we just move code around. Technical debt anyone? 😓 