### PR TITLE
Adapt gzip options to Alpine Linux

### DIFF
--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -155,8 +155,8 @@ module Wordmove
 
       def compress_command(path)
         command = ["gzip"]
-        command << "--best"
-        command << "--force"
+        command << "-9"
+        command << "-f"
         command << "\"#{path}\""
         command.join(" ")
       end
@@ -164,7 +164,7 @@ module Wordmove
       def uncompress_command(path)
         command = ["gzip"]
         command << "-d"
-        command << "--force"
+        command << "-f"
         command << "\"#{path}\""
         command.join(" ")
       end

--- a/spec/deployer/base_spec.rb
+++ b/spec/deployer/base_spec.rb
@@ -125,7 +125,7 @@ describe Wordmove::Deployer::Base do
         "dummy file.sql"
       )
 
-      expect(command).to eq("gzip --best --force \"dummy file.sql\"")
+      expect(command).to eq("gzip -9 -f \"dummy file.sql\"")
     end
   end
 
@@ -138,7 +138,7 @@ describe Wordmove::Deployer::Base do
         "dummy file.sql"
       )
 
-      expect(command).to eq("gzip -d --force \"dummy file.sql\"")
+      expect(command).to eq("gzip -d -f \"dummy file.sql\"")
     end
   end
 end


### PR DESCRIPTION
I am trying to run `wordmove` on Docker container [wordpress:fpm-alpine](https://github.com/docker-library/wordpress/tree/443eb3028423485fdf3943250db5609f3f37afbe/php7.2/fpm-alpine) based on [Alpine Linux](https://alpinelinux.org/)
on which `gzip` command does not have longhand options.
Because of that, `wordmove` get stuck at gzip deflation/inflation phases.

To use `-9` and `-f` instead of `--best` and `--force` will enhance compatibility.