### PR TITLE
Adapting local WordPress setup outside the project directory

### DIFF
--- a/lib/wordmove/deployer/ssh/wpcli_sql_adapter.rb
+++ b/lib/wordmove/deployer/ssh/wpcli_sql_adapter.rb
@@ -46,7 +46,8 @@ module Wordmove
           return if options[:no_adapt]
 
           logger.task_step true, "adapt dump for #{config_key}"
-          SqlAdapter::Wpcli.new(local, remote, config_key).command unless simulate?
+          path = local_options[:wordpress_path]
+          SqlAdapter::Wpcli.new(local, remote, config_key, path).command unless simulate?
         end
       end
     end

--- a/lib/wordmove/sql_adapter/wpcli.rb
+++ b/lib/wordmove/sql_adapter/wpcli.rb
@@ -2,11 +2,12 @@ module Wordmove
   module SqlAdapter
     class Wpcli
       attr_accessor :sql_content
-      attr_reader :from, :to
+      attr_reader :from, :to, :local_path
 
-      def initialize(source_config, dest_config, config_key)
+      def initialize(source_config, dest_config, config_key, local_path)
         @from = source_config[config_key]
         @to = dest_config[config_key]
+        @local_path = local_path
       end
 
       def command
@@ -14,7 +15,8 @@ module Wordmove
           raise UnmetPeerDependencyError, "WP-CLI is not installed or not in your $PATH"
         end
 
-        "wp search-replace #{from} #{to} --quiet --skip-columns=guid --all-tables --allow-root"
+        "wp search-replace --path=#{local_path} #{from} #{to} --quiet "\
+        "--skip-columns=guid --all-tables --allow-root"
       end
     end
   end

--- a/spec/sql_adapter/wpcli_spec.rb
+++ b/spec/sql_adapter/wpcli_spec.rb
@@ -2,18 +2,20 @@ describe Wordmove::SqlAdapter::Wpcli do
   let(:config_key) { :vhost }
   let(:source_config) { { vhost: 'sausage' } }
   let(:dest_config) { { vhost: 'bacon' } }
+  let(:local_path) { '/path/to/ham' }
   let(:adapter) do
     Wordmove::SqlAdapter::Wpcli.new(
       source_config,
       dest_config,
-      config_key
+      config_key,
+      local_path
     )
   end
 
   context "#command" do
     it "returns the right command as a string" do
       expect(adapter.command)
-        .to eq("wp search-replace sausage bacon --quiet "\
+        .to eq("wp search-replace --path=/path/to/ham sausage bacon --quiet "\
                "--skip-columns=guid --all-tables --allow-root")
     end
   end


### PR DESCRIPTION
I'm going to use Wordmove to manage multiple sites,  and have noticed that currently it rasies the error below if the local WordPress setup is outside the project directory:

```
Error: This does not seem to be a WordPress install. Pass --path=`path/to/wordpress` or run `wp core download`.
```

This PR is intended to solve this by always setting `--path` option to `wp search-replace`.

The path given to the options is retrieved by `local_options[:wordpress_path]`. Since it is where the local WordPress setup is located, I think setting it through `--path` does not harm any usage. Please correct me if not.

Related issue: https://github.com/welaika/wordmove/issues/407
