### PR TITLE
Fix doctor's local schema validation

### DIFF
--- a/lib/wordmove/assets/wordmove_schema_local.yml
+++ b/lib/wordmove/assets/wordmove_schema_local.yml
@@ -18,3 +18,13 @@ mapping:
       mysqldump_options:
       port:
       charset:
+  paths:
+    type: map
+    mapping:
+      wp_content:
+      wp_config:
+      uploads:
+      plugins:
+      mu_plugins:
+      themes:
+      languages:


### PR DESCRIPTION
In the schema was not present the actually
supported `paths` mapping.
This shuold fix `doctor` command validation
failing when using custom paths in the
movefile

The problem was raised in #506 (but does not solve it)