### PR TITLE
Add option to list local and remote vhosts.

### DIFF
--- a/lib/wordmove.rb
+++ b/lib/wordmove.rb
@@ -31,6 +31,7 @@ require 'wordmove/sql_adapter/default'
 require 'wordmove/sql_adapter/wpcli'
 require 'wordmove/wordpress_directory'
 require "wordmove/version"
+require "wordmove/list"
 
 require 'wordmove/generators/movefile_adapter'
 require 'wordmove/generators/movefile'

--- a/lib/wordmove.rb
+++ b/lib/wordmove.rb
@@ -31,7 +31,7 @@ require 'wordmove/sql_adapter/default'
 require 'wordmove/sql_adapter/wpcli'
 require 'wordmove/wordpress_directory'
 require "wordmove/version"
-require "wordmove/list"
+require "wordmove/environments_list"
 
 require 'wordmove/generators/movefile_adapter'
 require 'wordmove/generators/movefile'

--- a/lib/wordmove/cli.rb
+++ b/lib/wordmove/cli.rb
@@ -58,6 +58,23 @@ module Wordmove
       end
     end
 
+    desc "list", "List all environments and vhosts"
+    shared_options.each do |option, args|
+      method_option option, args
+    end
+    def list
+      Wordmove::List.start(options)
+    rescue Wordmove::MovefileNotFound => e
+      puts e.message
+      exit 1
+    rescue Psych::SyntaxError => e
+      puts "Your movefile is not parsable due to a syntax error: #{e.message}"
+      exit 1
+    rescue LoadError, StandardError => e
+      puts "Your movefile is not parsable. Please confirmt its format: #{e.message}"
+      exit 1
+    end
+
     desc "pull", "Pulls WP data from remote host to the local machine"
     shared_options.each do |option, args|
       method_option option, args

--- a/lib/wordmove/cli.rb
+++ b/lib/wordmove/cli.rb
@@ -63,15 +63,12 @@ module Wordmove
       method_option option, args
     end
     def list
-      Wordmove::List.start(options)
+      Wordmove::EnvironmentsList.print(options)
     rescue Wordmove::MovefileNotFound => e
       puts e.message
       exit 1
     rescue Psych::SyntaxError => e
       puts "Your movefile is not parsable due to a syntax error: #{e.message}"
-      exit 1
-    rescue LoadError, StandardError => e
-      puts "Your movefile is not parsable. Please confirmt its format: #{e.message}"
       exit 1
     end
 

--- a/lib/wordmove/list.rb
+++ b/lib/wordmove/list.rb
@@ -1,0 +1,70 @@
+module Wordmove
+  class List
+    class << self
+      def start(cli_options)
+        new(cli_options).start
+      end
+    end
+
+    def initialize(options)
+      @logger = Logger.new(STDOUT).tap { |l| l.level = Logger::INFO }
+      @movefile = Wordmove::Movefile.new(options[:config])
+      @remote_vhosts = []
+      @local_vhost = []
+    end
+
+    def start
+      contents = parse_movefile(movefile: movefile)
+      generate_vhost_list(contents: contents)
+      output
+    end
+
+    def output_string(vhost_list:)
+      return 'vhost list is empty' if vhost_list.empty?
+
+      ''.tap do |retval|
+        vhost_list.each do |entry|
+          retval << "#{entry[:env]}: #{entry[:vhost]}\n"
+        end
+      end
+    end
+
+    #
+    # return env, vhost map
+    # Exp. {:env=>:local, :vhost=>"http://vhost.local"},
+    #      {:env=>:production, :vhost=>"http://example.com"}
+    #
+    def generate_vhost_list(contents:)
+      # select object which has 'vhost' only
+      vhosts = select_vhost(contents: contents)
+      vhosts.each do |list|
+        if list[:env] == :local
+          @local_vhost << list
+        else
+          @remote_vhosts << list
+        end
+      end
+    end
+
+    private
+
+    attr_reader :movefile, :logger, :remote_vhosts, :local_vhost
+
+    def select_vhost(contents:)
+      target = contents.select { |_key, env| env[:vhost].present? }
+      target.map { |key, env| { env: key, vhost: env[:vhost] } }
+    end
+
+    def parse_movefile(movefile:)
+      movefile.fetch
+    end
+
+    def output
+      logger.task('Listing Local')
+      puts output_string(vhost_list: local_vhost)
+
+      logger.task('Listing Remotes')
+      puts output_string(vhost_list: remote_vhosts)
+    end
+  end
+end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -31,6 +31,45 @@ describe Wordmove::CLI do
     end
   end
 
+  context "#list" do
+    subject { cli.invoke(:list, []) }
+    # Werdmove.List.start should be called
+    it "delagates the command to List class" do
+      expect(Wordmove::List).to receive(:start)
+      subject
+    end
+
+    context 'without a valid movefile' do
+      context "no movefile" do
+        it { expect { subject }.to raise_error SystemExit }
+      end
+
+      context "syntax error movefile " do
+        before do
+          allow(Wordmove::List).to receive(:start).and_raise(Psych::SyntaxError)
+        end
+
+        it { expect { subject }.to raise_error SystemExit }
+      end
+
+      context "load error movefile" do
+        before do
+          allow(Wordmove::List).to receive(:start).and_raise(LoadError)
+        end
+
+        it { expect { subject }.to raise_error SystemExit }
+      end
+    end
+
+    context "with a movefile" do
+      subject { cli.invoke(:list, [], options) }
+      let(:options) { { config: movefile_path_for('Movefile') } }
+      it "invoke list without error" do
+        expect { subject }.not_to raise_error
+      end
+    end
+  end
+
   context "#push" do
     context "without a movefile" do
       it "it rescues from a MovefileNotFound exception" do

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -33,9 +33,10 @@ describe Wordmove::CLI do
 
   context "#list" do
     subject { cli.invoke(:list, []) }
-    # Werdmove.List.start should be called
-    it "delagates the command to List class" do
-      expect(Wordmove::List).to receive(:start)
+    let(:list_class) { Wordmove::EnvironmentsList }
+    # Werdmove::EnvironmentsList.print should be called
+    it "delagates the command to EnvironmentsList class" do
+      expect(list_class).to receive(:print)
       subject
     end
 
@@ -46,15 +47,12 @@ describe Wordmove::CLI do
 
       context "syntax error movefile " do
         before do
-          allow(Wordmove::List).to receive(:start).and_raise(Psych::SyntaxError)
-        end
-
-        it { expect { subject }.to raise_error SystemExit }
-      end
-
-      context "load error movefile" do
-        before do
-          allow(Wordmove::List).to receive(:start).and_raise(LoadError)
+          # Ref. https://github.com/ruby/psych/blob/master/lib/psych/syntax_error.rb#L8
+          # Arguments for initialization: file, line, col, offset, problem, context
+          args = [nil, 1, 5, 0,
+                  "found character that cannot start any token",
+                  "while scanning for the next token"]
+          allow(list_class).to receive(:print).and_raise(Psych::SyntaxError.new(*args))
         end
 
         it { expect { subject }.to raise_error SystemExit }

--- a/spec/environments_list_spec.rb
+++ b/spec/environments_list_spec.rb
@@ -1,12 +1,12 @@
-describe Wordmove::List do
+describe Wordmove::EnvironmentsList do
   let(:instance) { described_class.new(options) }
   let(:options) { {} }
 
-  describe ".start" do
-    subject { described_class.start(options) }
+  describe ".print" do
+    subject { described_class.print(options) }
 
-    it "create new instance and call its #start" do
-      expect_any_instance_of(described_class).to receive(:start).once
+    it "create new instance and call its #print" do
+      expect_any_instance_of(described_class).to receive(:print).once
       subject
     end
   end
@@ -23,8 +23,8 @@ describe Wordmove::List do
     end
   end
 
-  describe "#start" do
-    subject { instance.start }
+  describe "#print" do
+    subject { instance.print }
 
     context "non exist movefile" do
       let(:options) { { config: 'non_exists_path' } }
@@ -44,8 +44,8 @@ describe Wordmove::List do
     end
   end
 
-  describe "#output_string" do
-    subject { instance.output_string(vhost_list: vhost_list) }
+  describe "private #output_string" do
+    subject { instance.send(:output_string, vhost_list: vhost_list) }
 
     let(:vhost_list) do
       [

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -1,0 +1,103 @@
+describe Wordmove::List do
+  let(:instance) { described_class.new(options) }
+  let(:options) { {} }
+
+  describe ".start" do
+    subject { described_class.start(options) }
+
+    it "create new instance and call its #start" do
+      expect_any_instance_of(described_class).to receive(:start).once
+      subject
+    end
+  end
+
+  describe ".new" do
+    subject { instance }
+
+    it "created instance has logger" do
+      expect(subject.respond_to?(:logger, true)).to be_truthy
+    end
+
+    it "created instance has movefile" do
+      expect(subject.respond_to?(:movefile, true)).to be_truthy
+    end
+  end
+
+  describe "#start" do
+    subject { instance.start }
+
+    context "non exist movefile" do
+      let(:options) { { config: 'non_exists_path' } }
+      it "call parse_content" do
+        expect(instance).to receive(:parse_movefile).and_call_original
+        expect { subject }.to raise_error Wordmove::MovefileNotFound
+      end
+    end
+
+    context "valid movefile" do
+      let(:options) { { config: movefile_path_for('multi_environments') } }
+
+      it "call parse_content" do
+        expect(instance).to receive(:parse_movefile).and_call_original
+        subject
+      end
+    end
+  end
+
+  describe "#output_string" do
+    subject { instance.output_string(vhost_list: vhost_list) }
+
+    let(:vhost_list) do
+      [
+        { env: :staging, vhost: "https://staging.mysite.example.com" },
+        { env: :development, vhost: "http://development.mysite.example.com" }
+      ]
+    end
+
+    it "return expected output" do
+      result = subject
+      expect(result).to match('staging: https://staging.mysite.example.com')
+      expect(result).to match('development: http://development.mysite.example.com')
+    end
+  end
+
+  describe "private #select_vhost" do
+    subject { instance.send(:select_vhost, contents: contents) }
+
+    let(:contents) do
+      {
+        local: {
+          vhost: "http://localhost:8080",
+          wordpress_path: "/home/welaika/sites/your_site",
+          database: {
+            name: "database_name",
+            user: "user",
+            password: "password",
+            host: "host"
+          }
+        },
+        development: {
+          vhost: "http://development.mysite.example.com",
+          wordpress_path: "/var/www/your_site",
+          database: {
+            name: "database_name",
+            user: "user",
+            password: "password",
+            host: "host"
+          }
+        }
+      }
+    end
+
+    let(:result_list) do
+      [
+        { env: :local, vhost: "http://localhost:8080" },
+        { env: :development, vhost: "http://development.mysite.example.com" }
+      ]
+    end
+
+    it "return expected vhost list" do
+      expect(subject).to match(result_list)
+    end
+  end
+end


### PR DESCRIPTION
Hi, thanks for your great work!

I'm interested in this request: https://github.com/welaika/wordmove/issues/496 and tried to implement a simple command-line option to print remote and local vhosts.

I hope this would meet the request.

### Example putput

**When no movefile**

```bash
$ wordmove list
Could not find a valid Movefile
```

**When invalid  movefile**
 
```bash
$ wordmove list

▬▬ Using Movefile: ./Movefile ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬
Your movefile is not parsable due to a syntax error: (<unknown>): could not find expected ':' while scanning a simple key at line 3 column 3
```

**When valid movefile**

```bash
wordmove $ cp spec/fixtures/movefiles/multi_environments Movefile
wordmove $ wordmove list

▬▬ Using Movefile: ./Movefile ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬

▬▬ Listing Local ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬
local: http://localhost:8080

▬▬ Listing Remotes ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬
staging: http://staging.mysite.example.com
production: http://production.mysite.example.com
missing_protocol: http://production.mysite.example.com
```

### Spec

**for lib/wordmove/cli.rb**

```bash
$ rspec spec/cli_spec.rb --example='list'
Run options: include {:full_description=>/list/}

Wordmove::CLI
  #list
    delagates the command to List class
    without a valid movefile
      no movefile
Could not find a valid Movefile
        is expected to raise SystemExit
      syntax error movefile
Your movefile is not parsable. Please confirmt its format: wrong number of arguments (given 0, expected 6)
        is expected to raise SystemExit
      load error movefile
Your movefile is not parsable. Please confirmt its format: LoadError
        is expected to raise SystemExit
    with a movefile

▬▬ Using Movefile: ./spec/fixtures/movefiles/Movefile ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬

▬▬ Listing Local ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬
local: http://vhost.local

▬▬ Listing Remotes ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬
remote: http://example.com
      invoke list without error

Finished in 0.03992 seconds (files took 1.49 seconds to load)
5 examples, 0 failures
```

**for lib/wordmove/list.rb**

```bash
 rspec spec/list_spec.rb

Wordmove::List
  .start
    create new instance and call its #start
  .new
    created instance has logger
    created instance has movefile
  #start
    non exist movefile
      call parse_content
    valid movefile

▬▬ Using Movefile: ./spec/fixtures/movefiles/multi_environments ▬▬▬▬▬▬▬▬

▬▬ Listing Local ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬
local: http://localhost:8080

▬▬ Listing Remotes ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬
staging: http://staging.mysite.example.com
production: http://production.mysite.example.com
missing_protocol: http://production.mysite.example.com
      call parse_content
  #output_string
    return expected output
  private #select_vhost
    return expected vhost list

Finished in 0.04503 seconds (files took 1.66 seconds to load)
7 examples, 0 failures
```
