### PR TITLE
Filter explicit secrets from log

### DIFF
--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -30,15 +30,17 @@ module Wordmove
           '.'
         end
 
-        def logger
-          Logger.new(STDOUT).tap { |l| l.level = Logger::DEBUG }
+        def logger(secrets)
+          Logger.new(STDOUT, secrets).tap { |l| l.level = Logger::DEBUG }
         end
       end
 
       def initialize(environment, options = {})
         @environment = environment.to_sym
         @options = options
-        @logger = self.class.logger
+
+        movefile_secrets = Wordmove::Movefile.new.secrets
+        @logger = self.class.logger(movefile_secrets)
       end
 
       def push_db

--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -39,7 +39,7 @@ module Wordmove
         @environment = environment.to_sym
         @options = options
 
-        movefile_secrets = Wordmove::Movefile.new.secrets
+        movefile_secrets = Wordmove::Movefile.new(options[:config]).secrets
         @logger = self.class.logger(movefile_secrets)
       end
 

--- a/lib/wordmove/deployer/ftp.rb
+++ b/lib/wordmove/deployer/ftp.rb
@@ -2,7 +2,7 @@ module Wordmove
   module Deployer
     class FTP < Base
       def initialize(environment, options)
-        super
+        super(environment, options)
         ftp_options = remote_options[:ftp]
         @copier = Photocopier::FTP.new(ftp_options).tap { |c| c.logger = logger }
       end

--- a/lib/wordmove/deployer/ssh.rb
+++ b/lib/wordmove/deployer/ssh.rb
@@ -9,7 +9,7 @@ module Wordmove
                   :local_gzipped_backup_path
 
       def initialize(environment, options)
-        super
+        super(environment, options)
         ssh_options = remote_options[:ssh]
 
         if simulate? && ssh_options[:rsync_options]

--- a/lib/wordmove/logger.rb
+++ b/lib/wordmove/logger.rb
@@ -6,36 +6,35 @@ module Wordmove
       prefix = "▬" * 2
       title = " #{title} "
       padding = "▬" * padding_length(title)
-
-      puts "\n" + prefix + title.light_white + padding
+      add(INFO, prefix + title.light_white + padding)
     end
 
     def task_step(local_step, title)
       if local_step
-        puts "    local".cyan + " | ".black + title.to_s
+        add(INFO, "    local".cyan + " | ".black + title.to_s)
       else
-        puts "   remote".yellow + " | ".black + title.to_s
+        add(INFO, "   remote".yellow + " | ".black + title.to_s)
       end
     end
 
     def error(message)
-      puts "    ❌  error".red + " | ".black + message.to_s
+      add(ERROR, "    ❌  error".red + " | ".black + message.to_s)
     end
 
     def success(message)
-      puts "    ✅  success".green + " | ".black + message.to_s
+      add(INFO, "    ✅  success".green + " | ".black + message.to_s)
     end
 
     def debug(message)
-      puts "    🛠  debug".magenta + " | ".black + message.to_s
+      add(DEBUG, "    🛠  debug".magenta + " | ".black + message.to_s)
     end
 
     def warn(message)
-      puts "    ⚠️  warning".yellow + " | ".black + message.to_s
+      add(WARN, "    ⚠️  warning".yellow + " | ".black + message.to_s)
     end
 
     def info(message)
-      puts "    ℹ️  info".yellow + " | ".black + message.to_s
+      add(INFO, "    ℹ️  info".yellow + " | ".black + message.to_s)
     end
 
     def plain(message)

--- a/lib/wordmove/logger.rb
+++ b/lib/wordmove/logger.rb
@@ -2,6 +2,16 @@ module Wordmove
   class Logger < ::Logger
     MAX_LINE = 70
 
+    def initialize(device, strings_to_hide = [])
+      super(device, formatter: proc { |_severity, _datetime, _progname, msg|
+        if strings_to_hide.empty?
+          msg
+        else
+          "\n#{msg}\n".gsub(Regexp.new(strings_to_hide.join('|')), '[secret]')
+        end
+      })
+    end
+
     def task(title)
       prefix = "▬" * 2
       title = " #{title} "

--- a/lib/wordmove/logger.rb
+++ b/lib/wordmove/logger.rb
@@ -7,7 +7,7 @@ module Wordmove
         if strings_to_hide.empty?
           msg
         else
-          "\n#{msg}\n".gsub(Regexp.new(strings_to_hide.join('|')), '[secret]')
+          msg.gsub(Regexp.new(strings_to_hide.join('|')), '[secret]')
         end
       })
     end

--- a/lib/wordmove/movefile.rb
+++ b/lib/wordmove/movefile.rb
@@ -53,6 +53,24 @@ module Wordmove
       (options[:environment] || available_enviroments.first).to_sym
     end
 
+    def secrets
+      options = fetch(false)
+
+      secrets = []
+      options.each_key do |env|
+        secrets << options.dig(env, :database, :password)
+        secrets << options.dig(env, :database, :host)
+        secrets << options.dig(env, :vhost)
+        secrets << options.dig(env, :ssh, :password)
+        secrets << options.dig(env, :ssh, :host)
+        secrets << options.dig(env, :ftp, :password)
+        secrets << options.dig(env, :ftp, :host)
+        secrets << options.dig(env, :wordpress_path)
+      end
+
+      secrets.compact.delete_if(&:empty?)
+    end
+
     private
 
     def extract_available_envs(options)

--- a/lib/wordmove/movefile.rb
+++ b/lib/wordmove/movefile.rb
@@ -16,7 +16,11 @@ module Wordmove
                 end
 
       if entries.empty?
-        raise MovefileNotFound, "Could not find a valid Movefile" if last_dir?(start_dir)
+        if last_dir?(start_dir)
+          raise MovefileNotFound, "Could not find a valid Movefile. Searched"\
+                                  " for filename \"#{name}\" in folder \"#{start_dir}\""
+        end
+
         @start_dir = upper_dir(start_dir)
         return fetch
       end

--- a/spec/deployer/base_spec.rb
+++ b/spec/deployer/base_spec.rb
@@ -3,7 +3,6 @@ describe Wordmove::Deployer::Base do
     { config: movefile_path_for("multi_environments") }
   end
   context ".deployer_for" do
-
     context "with more then one environment, but none chosen" do
       it "raises an exception" do
         expect { described_class.deployer_for(options) }

--- a/spec/deployer/base_spec.rb
+++ b/spec/deployer/base_spec.rb
@@ -1,8 +1,8 @@
 describe Wordmove::Deployer::Base do
+  let(:options) do
+    { config: movefile_path_for("multi_environments") }
+  end
   context ".deployer_for" do
-    let(:options) do
-      { config: movefile_path_for("multi_environments") }
-    end
 
     context "with more then one environment, but none chosen" do
       it "raises an exception" do
@@ -63,7 +63,7 @@ describe Wordmove::Deployer::Base do
   end
 
   context "#mysql_dump_command" do
-    let(:deployer) { described_class.new(:dummy_env) }
+    let(:deployer) { described_class.new(:dummy_env, options) }
 
     it "creates a valid mysqldump command" do
       command = deployer.send(
@@ -91,7 +91,7 @@ describe Wordmove::Deployer::Base do
   end
 
   context "#mysql_import_command" do
-    let(:deployer) { described_class.new(:dummy_env) }
+    let(:deployer) { described_class.new(:dummy_env, options) }
 
     it "creates a valid mysql import command" do
       command = deployer.send(
@@ -117,7 +117,7 @@ describe Wordmove::Deployer::Base do
   end
 
   context "#compress_command" do
-    let(:deployer) { described_class.new(:dummy_env) }
+    let(:deployer) { described_class.new(:dummy_env, options) }
 
     it "cerates a valid gzip command" do
       command = deployer.send(
@@ -130,7 +130,7 @@ describe Wordmove::Deployer::Base do
   end
 
   context "#uncompress_command" do
-    let(:deployer) { described_class.new(:dummy_env) }
+    let(:deployer) { described_class.new(:dummy_env, options) }
 
     it "creates a valid gunzip command" do
       command = deployer.send(

--- a/spec/fixtures/movefiles/with_secrets
+++ b/spec/fixtures/movefiles/with_secrets
@@ -1,0 +1,29 @@
+global:
+  sql_adapter: "default"
+local:
+  vhost: "http://secrets.local"
+  wordpress_path: "~/dev/sites/your_site"
+  database:
+    name: "database_name"
+    user: "user"
+    password: "local_database_password"
+    host: "local_database_host"
+remote:
+  vhost: "http://secrets.example.com"
+  wordpress_path: "/var/www/your_site"
+  database:
+    name: "database_name"
+    user: "user"
+    password: "remote_database_password"
+    host: "remote_database_host"
+  ssh:
+    user: "user"
+    password: "ssh_password"
+    host: "ssh_host"
+    port: 30000
+  ftp:
+    user: "user"
+    password: "ftp_password"
+    host: "ftp_host"
+foo:
+  vhost: "https://foo.bar"

--- a/spec/fixtures/movefiles/with_secrets_with_empty_local_db_password
+++ b/spec/fixtures/movefiles/with_secrets_with_empty_local_db_password
@@ -1,0 +1,27 @@
+global:
+  sql_adapter: "default"
+local:
+  vhost: "http://secrets.local"
+  wordpress_path: "~/dev/sites/your_site"
+  database:
+    name: "database_name"
+    user: "user"
+    password: ""
+    host: "local_database_host"
+remote:
+  vhost: "http://secrets.example.com"
+  wordpress_path: "/var/www/your_site"
+  database:
+    name: "database_name"
+    user: "user"
+    password: "remote_database_password"
+    host: "remote_database_host"
+  ssh:
+    user: "user"
+    password: "ssh_password"
+    host: "ssh_host"
+    port: 30000
+  ftp:
+    user: "user"
+    password: "ftp_password"
+    host: "ftp_host"

--- a/spec/logger/logger_spec.rb
+++ b/spec/logger/logger_spec.rb
@@ -1,0 +1,13 @@
+describe Wordmove::Logger do
+  context "#info" do
+    context "having some string to filter" do
+      let(:logger) { described_class.new(STDOUT, ['hidden']) }
+
+      it "will hide the passed strings" do
+        expect { logger.info('What I write is hidden') }
+          .to output(/What I write is \[secret\]/)
+          .to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/movefile_spec.rb
+++ b/spec/movefile_spec.rb
@@ -139,4 +139,48 @@ describe Wordmove::Movefile do
       end
     end
   end
+
+  context ".secrets" do
+    let(:path) { movefile_path_for('with_secrets') }
+
+    it "returns all the secrets found in movefile" do
+      movefile = described_class.new('with_secrets', path)
+      expect(movefile.secrets).to eq(
+        %w[
+          local_database_password
+          local_database_host
+          http://secrets.local
+          ~/dev/sites/your_site
+          remote_database_password
+          remote_database_host
+          http://secrets.example.com
+          ssh_password
+          ssh_host
+          ftp_password
+          ftp_host
+          /var/www/your_site
+          https://foo.bar
+        ]
+      )
+    end
+
+    it "returns all the secrets found in movefile excluding empty string values" do
+      movefile = described_class.new('with_secrets_with_empty_local_db_password', path)
+      expect(movefile.secrets).to eq(
+        %w[
+          local_database_host
+          http://secrets.local
+          ~/dev/sites/your_site
+          remote_database_password
+          remote_database_host
+          http://secrets.example.com
+          ssh_password
+          ssh_host
+          ftp_password
+          ftp_host
+          /var/www/your_site
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://github.com/welaika/wordmove/issues/531

## Goal

Hide some sensitive data present in `movefile.yml` from the STDOUT log.

## Notes

* I've not used external libraries such as suggested in the issue, but I relied on standard ruby Logger
* Words to be hidden (secrets) are an arbitrary subset of movefile's options
* Secrets are hidden during all the delpoy processes (`puhs`/`pull`) at the moment; this PR does not pretend to cover all the possible STDOUT prints. Secrets could still be printed in certain scenarios:
  * unhandled exceptions
  * `doctor`'s output
* this feature naturally takes into consideration secret words passed by environment variables
* no configuration is offered to tune this feature and it's not meant to be other than that in the current PR

## Refactor

I found a naif pattern: in subclasses initializers (`Wordmove::Deployer::Ftp` and `Wordmove::Deployer::Ssh`) `super` (from `Wordmove::Deployer::Base`) was called without passing "up"  arguments. It has always been like that, but now the problem arose. I **think** this was a problem because even if the `super` initializer had default arguments values, I think it's correct to pass arguments around, since `Base` class is never called directly...looks obvious to me at the moment.

With this new feature the shortcoming was breaking the CI, so I refactored it and refactored involved tests as well.