### PR TITLE
When Movefile#fetch it's called recursively, arguments must be passed on

### DIFF
--- a/lib/wordmove/movefile.rb
+++ b/lib/wordmove/movefile.rb
@@ -22,7 +22,7 @@ module Wordmove
         end
 
         @start_dir = upper_dir(start_dir)
-        return fetch
+        return fetch(verbose)
       end
 
       found = entries.first


### PR DESCRIPTION
In some circumstances we had multiple and unwanted log such as

`Using Movefile: xyz`

This happened because the `Movefile#fetch` method has a recursive branch in which arguments (`verbose` actually`) was not passed to the nested call.