### PR TITLE
Hooks refactor

### DIFF
--- a/lib/wordmove/assets/wordmove_schema_remote.yml
+++ b/lib/wordmove/assets/wordmove_schema_remote.yml
@@ -98,6 +98,8 @@ mapping:
                     type: str
                     required: true
                     pattern: /\Alocal\Z|\Aremote\Z/
+                  raise:
+                    type: bool
           after:
             type: seq
             sequence:
@@ -110,6 +112,8 @@ mapping:
                     type: str
                     required: true
                     pattern: /\Alocal\Z|\Aremote\Z/
+                  raise:
+                    type: bool
       pull:
         type: map
         mapping:
@@ -125,6 +129,8 @@ mapping:
                     type: str
                     required: true
                     pattern: /\Alocal\Z|\Aremote\Z/
+                  raise:
+                    type: bool
           after:
             type: seq
             sequence:
@@ -137,6 +143,8 @@ mapping:
                     type: str
                     required: true
                     pattern: /\Alocal\Z|\Aremote\Z/
+                  raise:
+                    type: bool
 
   forbid:
     type: map

--- a/lib/wordmove/assets/wordmove_schema_remote.yml
+++ b/lib/wordmove/assets/wordmove_schema_remote.yml
@@ -87,52 +87,57 @@ mapping:
         type: map
         mapping:
           before:
-            type: map
-            mapping:
-              local:
-                type: seq
-                sequence:
-                  - type: str
-              remote:
-                type: seq
-                sequence:
-                  - type: str
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  command:
+                    type: str
+                    required: true
+                  where:
+                    type: str
+                    required: true
+                    pattern: /\Alocal\Z|\Aremote\Z/
           after:
-            type: map
-            mapping:
-              local:
-                type: seq
-                sequence:
-                  - type: str
-              remote:
-                type: seq
-                sequence:
-                  - type: str
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  command:
+                    type: str
+                    required: true
+                  where:
+                    type: str
+                    required: true
+                    pattern: /\Alocal\Z|\Aremote\Z/
       pull:
         type: map
         mapping:
           before:
-            type: map
-            mapping:
-              local:
-                type: seq
-                sequence:
-                  - type: str
-              remote:
-                type: seq
-                sequence:
-                  - type: str
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  command:
+                    type: str
+                    required: true
+                  where:
+                    type: str
+                    required: true
+                    pattern: /\Alocal\Z|\Aremote\Z/
           after:
-            type: map
-            mapping:
-              local:
-                type: seq
-                sequence:
-                  - type: str
-              remote:
-                type: seq
-                sequence:
-                  - type: str
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  command:
+                    type: str
+                    required: true
+                  where:
+                    type: str
+                    required: true
+                    pattern: /\Alocal\Z|\Aremote\Z/
+
   forbid:
     type: map
     mapping:

--- a/lib/wordmove/hook.rb
+++ b/lib/wordmove/hook.rb
@@ -41,13 +41,17 @@ module Wordmove
       def local_hooks
         return [] if empty_step?
 
-        options[action][step][:local] || []
+        options[action][step]
+          .select { |hook| hook[:where] == 'local' }
+          .map { |hook| hook[:command] } || []
       end
 
       def remote_hooks
         return [] if empty_step?
 
-        options[action][step][:remote] || []
+        options[action][step]
+          .select { |hook| hook[:where] == 'remote' }
+          .map { |hook| hook[:command] } || []
       end
 
       private

--- a/spec/fixtures/movefiles/with_hooks
+++ b/spec/fixtures/movefiles/with_hooks
@@ -115,3 +115,24 @@ ssh_with_hooks_which_return_error:
       after:
         - command: 'exit 127'
           where: local
+
+ssh_with_hooks_which_return_error_raise_false:
+  vhost: "http://staging.mysite.example.com"
+  wordpress_path: "/var/www/your_site" # use an absolute path here
+
+  database:
+    name: "database_name"
+    user: "user"
+    password: "password"
+    host: "host"
+
+  ssh:
+    host: "staging.mysite.example.com"
+    user: "user"
+
+  hooks:
+    push:
+      after:
+        - command: 'exit 127'
+          where: local
+          raise: false

--- a/spec/fixtures/movefiles/with_hooks
+++ b/spec/fixtures/movefiles/with_hooks
@@ -30,27 +30,28 @@ ssh_with_hooks:
   hooks:
     push:
       before:
-        local:
-          - 'echo "Calling hook push before local"'
-          - 'pwd'
-        remote:
-          - 'echo "Calling hook push before remote"'
+        - command: 'echo "Calling hook push before local"'
+          where: local
+        - command: 'pwd'
+          where: local
+        - command: 'echo "Calling hook push before remote"'
+          where: remote
       after:
-        local:
-          - 'echo "Calling hook push after local"'
-        remote:
-          - 'echo "Calling hook push after remote"'
+        - command: 'echo "Calling hook push after local"'
+          where: local
+        - command: 'echo "Calling hook push after remote"'
+          where: remote
     pull:
       before:
-        local:
-          - 'echo "Calling hook pull before local"'
-        remote:
-          - 'echo "Calling hook pull before remote"'
+        - command: 'echo "Calling hook pull before local"'
+          where: local
+        - command: 'echo "Calling hook pull before remote"'
+          where: remote
       after:
-        local:
-          - 'echo "Calling hook pull after local"'
-        remote:
-          - 'echo "Calling hook pull after remote"'
+        - command: 'echo "Calling hook pull after local"'
+          where: local
+        - command: 'echo "Calling hook pull after remote"'
+          where: remote
 
 ftp_with_hooks:
   vhost: "http://production.mysite.example.com"
@@ -71,8 +72,8 @@ ftp_with_hooks:
   hooks:
     push:
       before:
-        remote:
-          - echo "Calling hook push before remote"
+        - command: echo "Calling hook push before remote"
+          where: remote
 
 ssh_with_hooks_partially_filled:
   vhost: "http://staging.mysite.example.com"
@@ -92,8 +93,8 @@ ssh_with_hooks_partially_filled:
     push:
     pull:
       after:
-        local:
-          - echo "I've partially configured my hooks"
+        - command: echo "I've partially configured my hooks"
+          where: local
 
 ssh_with_hooks_which_return_error:
   vhost: "http://staging.mysite.example.com"
@@ -112,5 +113,5 @@ ssh_with_hooks_which_return_error:
   hooks:
     push:
       after:
-        local:
-          - 'exit 127'
+        - command: 'exit 127'
+          where: local

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -79,6 +79,21 @@ describe Wordmove::Hook do
           end.to output(/Error code: 127/)
             .to_stdout_from_any_process
         end
+
+        context "with raise set to `false`" do
+          let(:options) do
+            common_options.merge("environment" => 'ssh_with_hooks_which_return_error_raise_false')
+          end
+
+          it "logs an error without raising an exeption" do
+            expect do
+              expect do
+                cli.invoke(:push, [], options)
+              end.to_not raise_exception
+            end.to output(/Error code: 127/)
+              .to_stdout_from_any_process
+          end
+        end
       end
     end
 
@@ -194,13 +209,16 @@ describe Wordmove::Hook::Config do
 
   context "#local_hooks" do
     it "returns all the local hooks" do
-      expect(config.local_hooks).to eq ['echo "Calling hook push before local"', 'pwd']
+      expect(config.remote_hooks).to be_kind_of(Array)
+      expect(config.local_hooks.first[:command]).to eq 'echo "Calling hook push before local"'
+      expect(config.local_hooks.second[:command]).to eq 'pwd'
     end
   end
 
   context "#remote_hooks" do
     it "returns all the remote hooks" do
-      expect(config.remote_hooks).to eq ['echo "Calling hook push before remote"']
+      expect(config.remote_hooks).to be_kind_of(Array)
+      expect(config.remote_hooks.first[:command]).to eq 'echo "Calling hook push before remote"'
     end
   end
 


### PR DESCRIPTION
Problem and solution were analysed in #532 

One more important feature is added here: hooks can be configured to not raise exception if their command fails. This is crucial when you have a deploy chain where some commands may fail (maybe due to external services? or just because they are not important?) and you want your deploy to continue.
The error is visibly logged by the way.

This is an example of a working new `hooks` structure inside `movefile.yml`

```yml
  hooks:
    push:
    pull:
      before:
        - command: 'exit 1'
          where: local
          raise: false
      after:
        - command: 'exit 1'
          where: remote
```

Hooks are always executed in order and are synchronous, so the configuration should be procedurally fully respected.

The initial goal is accomplished, since we can order before and after hooks with any regard to the environment where they'll be executed.