### PR TITLE
Refactor Hook class to not group commands by remote/local

### DIFF
--- a/lib/wordmove/hook.rb
+++ b/lib/wordmove/hook.rb
@@ -81,20 +81,20 @@ module Wordmove
         parent.logger
       end
 
-      def self.run(command_object, options, simulate = false)
+      def self.run(command_hash, options, simulate = false)
         wordpress_path = options[:wordpress_path]
 
-        logger.task_step true, "Exec command: #{command_object[:command]}"
+        logger.task_step true, "Exec command: #{command_hash[:command]}"
         return true if simulate
 
-        stdout_return = `cd #{wordpress_path} && #{command_object[:command]} 2>&1`
+        stdout_return = `cd #{wordpress_path} && #{command_hash[:command]} 2>&1`
         logger.task_step true, "Output: #{stdout_return}"
 
         if $CHILD_STATUS.exitstatus.zero?
           logger.success ""
         else
           logger.error "Error code: #{$CHILD_STATUS.exitstatus}"
-          raise Wordmove::LocalHookException unless command_object[:raise].eql? false
+          raise Wordmove::LocalHookException unless command_hash[:raise].eql? false
         end
       end
     end

--- a/lib/wordmove/hook.rb
+++ b/lib/wordmove/hook.rb
@@ -16,7 +16,7 @@ module Wordmove
         step
       )
 
-      return if hooks.all_commands.empty?
+      return if hooks.empty?
 
       logger.task "Running #{action}/#{step} hooks"
 

--- a/lib/wordmove/hook.rb
+++ b/lib/wordmove/hook.rb
@@ -41,7 +41,7 @@ module Wordmove
 
     Config = Struct.new(:options, :action, :step) do
       def empty?
-        (local_commands + remote_commands).empty?
+        all_commands.empty?
       end
 
       def all_commands

--- a/lib/wordmove/hook.rb
+++ b/lib/wordmove/hook.rb
@@ -4,6 +4,7 @@ module Wordmove
       Logger.new(STDOUT).tap { |l| l.level = Logger::DEBUG }
     end
 
+    # rubocop:disable Metrics/MethodLength
     def self.run(action, step, cli_options)
       movefile = Wordmove::Movefile.new(cli_options[:config])
       options = movefile.fetch(false)
@@ -15,37 +16,48 @@ module Wordmove
         step
       )
 
-      unless hooks.local_hooks.empty?
-        Wordmove::Hook::Local.run(hooks.local_hooks, options[:local], cli_options[:simulate])
+      return if hooks.all_commands.empty?
+
+      logger.task "Running #{action}/#{step} hooks"
+
+      hooks.all_commands.each do |command|
+        case command[:where]
+        when 'local'
+          Wordmove::Hook::Local.run(command, options[:local], cli_options[:simulate])
+        when 'remote'
+          if options[environment][:ftp]
+            logger.debug "You have configured remote hooks to run over "\
+                         "an FTP connection, but this is not possible. Skipping."
+            next
+          end
+
+          Wordmove::Hook::Remote.run(command, options[environment], cli_options[:simulate])
+        else
+          next
+        end
       end
-
-      return if hooks.remote_hooks.empty?
-
-      if options[environment][:ftp]
-        logger.debug "You have configured remote hooks to run over "\
-                     "an FTP connection, but this is not possible. Skipping."
-
-        return
-      end
-
-      Wordmove::Hook::Remote.run(
-        hooks.remote_hooks, options[environment], cli_options[:simulate]
-      )
     end
+    # rubocop:enable Metrics/MethodLength
 
     Config = Struct.new(:options, :action, :step) do
       def empty?
-        (local_hooks + remote_hooks).empty?
+        (local_commands + remote_commands).empty?
       end
 
-      def local_hooks
+      def all_commands
+        return [] if empty_step?
+
+        options[action][step] || []
+      end
+
+      def local_commands
         return [] if empty_step?
 
         options[action][step]
           .select { |hook| hook[:where] == 'local' } || []
       end
 
-      def remote_hooks
+      def remote_commands
         return [] if empty_step?
 
         options[action][step]
@@ -69,24 +81,20 @@ module Wordmove
         parent.logger
       end
 
-      def self.run(hooks, options, simulate = false)
-        logger.task "Running local hooks"
-
+      def self.run(command_object, options, simulate = false)
         wordpress_path = options[:wordpress_path]
 
-        hooks.each do |hook|
-          logger.task_step true, "Exec command: #{hook[:command]}"
-          return true if simulate
+        logger.task_step true, "Exec command: #{command_object[:command]}"
+        return true if simulate
 
-          stdout_return = `cd #{wordpress_path} && #{hook[:command]} 2>&1`
-          logger.task_step true, "Output: #{stdout_return}"
+        stdout_return = `cd #{wordpress_path} && #{command_object[:command]} 2>&1`
+        logger.task_step true, "Output: #{stdout_return}"
 
-          if $CHILD_STATUS.exitstatus.zero?
-            logger.success ""
-          else
-            logger.error "Error code: #{$CHILD_STATUS.exitstatus}"
-            raise Wordmove::LocalHookException unless hook[:raise].eql? false
-          end
+        if $CHILD_STATUS.exitstatus.zero?
+          logger.success ""
+        else
+          logger.error "Error code: #{$CHILD_STATUS.exitstatus}"
+          raise Wordmove::LocalHookException unless command_object[:raise].eql? false
         end
       end
     end
@@ -96,28 +104,25 @@ module Wordmove
         parent.logger
       end
 
-      def self.run(hooks, options, simulate = false)
-        logger.task "Running remote hooks"
-
+      def self.run(command_hash, options, simulate = false)
         ssh_options = options[:ssh]
         wordpress_path = options[:wordpress_path]
 
         copier = Photocopier::SSH.new(ssh_options).tap { |c| c.logger = logger }
-        hooks.each do |hook|
-          logger.task_step false, "Exec command: #{hook[:command]}"
-          return true if simulate
 
-          stdout, stderr, exit_code =
-            copier.exec!("cd #{wordpress_path} && #{hook[:command]}")
+        logger.task_step false, "Exec command: #{command_hash[:command]}"
+        return true if simulate
 
-          if exit_code.zero?
-            logger.task_step false, "Output: #{stdout}"
-            logger.success ""
-          else
-            logger.task_step false, "Output: #{stderr}"
-            logger.error "Error code #{exit_code}"
-            raise Wordmove::RemoteHookException unless hook[:raise].eql? false
-          end
+        stdout, stderr, exit_code =
+          copier.exec!("cd #{wordpress_path} && #{command_hash[:command]}")
+
+        if exit_code.zero?
+          logger.task_step false, "Output: #{stdout}"
+          logger.success ""
+        else
+          logger.task_step false, "Output: #{stderr}"
+          logger.error "Error code #{exit_code}"
+          raise Wordmove::RemoteHookException unless command_hash[:raise].eql? false
         end
       end
     end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -207,31 +207,31 @@ describe Wordmove::Hook::Config do
   let(:options) { movefile.fetch(false)[:ssh_with_hooks][:hooks] }
   let(:config) { described_class.new(options, :push, :before) }
 
-  context "#local_hooks" do
+  context "#local_commands" do
     it "returns all the local hooks" do
-      expect(config.remote_hooks).to be_kind_of(Array)
-      expect(config.local_hooks.first[:command]).to eq 'echo "Calling hook push before local"'
-      expect(config.local_hooks.second[:command]).to eq 'pwd'
+      expect(config.remote_commands).to be_kind_of(Array)
+      expect(config.local_commands.first[:command]).to eq 'echo "Calling hook push before local"'
+      expect(config.local_commands.second[:command]).to eq 'pwd'
     end
   end
 
-  context "#remote_hooks" do
+  context "#remote_commands" do
     it "returns all the remote hooks" do
-      expect(config.remote_hooks).to be_kind_of(Array)
-      expect(config.remote_hooks.first[:command]).to eq 'echo "Calling hook push before remote"'
+      expect(config.remote_commands).to be_kind_of(Array)
+      expect(config.remote_commands.first[:command]).to eq 'echo "Calling hook push before remote"'
     end
   end
 
   context "#empty?" do
     it "returns true if both local and remote hooks are empty" do
-      allow(config).to receive(:local_hooks).and_return([])
-      allow(config).to receive(:remote_hooks).and_return([])
+      allow(config).to receive(:local_commands).and_return([])
+      allow(config).to receive(:remote_commands).and_return([])
 
       expect(config.empty?).to be true
     end
 
     it "returns false if there is at least one hook registered" do
-      allow(config).to receive(:local_hooks).and_return([])
+      allow(config).to receive(:local_commands).and_return([])
 
       expect(config.empty?).to be false
     end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -17,20 +17,40 @@ describe Wordmove::Hook do
       cli.invoke(:push, [], options)
 
       expect(Wordmove::Hook::Local).to(
-        have_received(:run).with({command: 'echo "Calling hook push before local"', where: 'local'}, an_instance_of(Hash), nil).ordered
+        have_received(:run).with(
+          { command: 'echo "Calling hook push before local"', where: 'local' },
+          an_instance_of(Hash),
+          nil
+        ).ordered
       )
       expect(Wordmove::Hook::Local).to(
-        have_received(:run).with({command: 'pwd', where: 'local'}, an_instance_of(Hash), nil).ordered
+        have_received(:run).with(
+          { command: 'pwd', where: 'local' },
+          an_instance_of(Hash),
+          nil
+        ).ordered
       )
       expect(Wordmove::Hook::Remote).to(
-        have_received(:run).with({command: 'echo "Calling hook push before remote"', where: 'remote'}, an_instance_of(Hash), nil).ordered
+        have_received(:run).with(
+          { command: 'echo "Calling hook push before remote"', where: 'remote' },
+          an_instance_of(Hash),
+          nil
+        ).ordered
       )
 
       expect(Wordmove::Hook::Local).to(
-        have_received(:run).with({command: 'echo "Calling hook push after local"', where: 'local'}, an_instance_of(Hash), nil).ordered
+        have_received(:run).with(
+          { command: 'echo "Calling hook push after local"', where: 'local' },
+          an_instance_of(Hash),
+          nil
+        ).ordered
       )
       expect(Wordmove::Hook::Remote).to(
-        have_received(:run).with({command: 'echo "Calling hook push after remote"', where: 'remote'}, an_instance_of(Hash), nil).ordered
+        have_received(:run).with(
+          { command: 'echo "Calling hook push after remote"', where: 'remote' },
+          an_instance_of(Hash),
+          nil
+        ).ordered
       )
     end
   end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -273,9 +273,8 @@ describe Wordmove::Hook::Config do
   end
 
   context "#empty?" do
-    it "returns true if both local and remote hooks are empty" do
-      allow(config).to receive(:local_commands).and_return([])
-      allow(config).to receive(:remote_commands).and_return([])
+    it "returns true if `all_commands` array is empty" do
+      allow(config).to receive(:all_commands).and_return([])
 
       expect(config.empty?).to be true
     end


### PR DESCRIPTION
thus preserving order

Should fix #561 , but I have no idea about how to test this "sort" of execution order in a sane way...