### PR TITLE
More friendly error message for nonexistent env

### DIFF
--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -13,16 +13,6 @@ module Wordmove
           options = movefile.fetch.merge! cli_options
           environment = movefile.environment(cli_options)
 
-          if options[environment].nil?
-            raise(
-              UndefinedEnvironment,
-              %W[
-                No environment found for #{environment}.
-                Available Environments: #{movefile.extract_available_envs(options).join(' ')}
-              ].join(' ')
-            )
-          end
-
           return FTP.new(environment, options) if options[environment][:ftp]
 
           if options[environment][:ssh] && options[:global][:sql_adapter] == 'wpcli'

--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -13,6 +13,16 @@ module Wordmove
           options = movefile.fetch.merge! cli_options
           environment = movefile.environment(cli_options)
 
+          if options[environment].nil?
+            raise(
+              UndefinedEnvironment,
+              %W[
+                No environment found for #{environment}.
+                Available Environments: #{movefile.extract_available_envs(options).join(' ')}
+              ].join(' ')
+            )
+          end
+
           return FTP.new(environment, options) if options[environment][:ftp]
 
           if options[environment][:ssh] && options[:global][:sql_adapter] == 'wpcli'

--- a/lib/wordmove/movefile.rb
+++ b/lib/wordmove/movefile.rb
@@ -47,8 +47,8 @@ module Wordmove
       available_enviroments = extract_available_envs(options)
       options.merge!(cli_options).deep_symbolize_keys!
 
-      if available_enviroments.size > 1 && options[:environment] != 'local'
-        if options[:environment].nil?
+      if options[:environment] != 'local'
+        if available_enviroments.size > 1 && options[:environment].nil?
           raise(
             UndefinedEnvironment,
             "You need to specify an environment with --environment parameter"

--- a/lib/wordmove/movefile.rb
+++ b/lib/wordmove/movefile.rb
@@ -47,11 +47,18 @@ module Wordmove
       available_enviroments = extract_available_envs(options)
       options.merge!(cli_options).deep_symbolize_keys!
 
-      if available_enviroments.size > 1 && options[:environment].nil?
-        raise(
-          UndefinedEnvironment,
-          "You need to specify an environment with --environment parameter"
-        )
+      if available_enviroments.size > 1 && options[:environment] != 'local'
+        if options[:environment].nil?
+          raise(
+            UndefinedEnvironment,
+            "You need to specify an environment with --environment parameter"
+          )
+        end
+
+        unless available_enviroments.include? options[:environment].to_sym
+          raise UndefinedEnvironment, "No environment found for \"#{options[:environment]}\". "\
+                                      "Available Environments: #{available_enviroments.join(' ')}"
+        end
       end
 
       (options[:environment] || available_enviroments.first).to_sym

--- a/lib/wordmove/movefile.rb
+++ b/lib/wordmove/movefile.rb
@@ -55,9 +55,11 @@ module Wordmove
           )
         end
 
-        unless available_enviroments.include? options[:environment].to_sym
-          raise UndefinedEnvironment, "No environment found for \"#{options[:environment]}\". "\
-                                      "Available Environments: #{available_enviroments.join(' ')}"
+        if options[:environment].present?
+          unless available_enviroments.include?(options[:environment].to_sym)
+            raise UndefinedEnvironment, "No environment found for \"#{options[:environment]}\". "\
+                                        "Available Environments: #{available_enviroments.join(' ')}"
+          end
         end
       end
 

--- a/spec/deployer/base_spec.rb
+++ b/spec/deployer/base_spec.rb
@@ -10,6 +10,16 @@ describe Wordmove::Deployer::Base do
       end
     end
 
+    context "with more then one environment, but invalid chosen" do
+      it "raises an exception" do
+        options[:environment] = "doesnotexist"
+        options[:simulate] = true
+
+        expect { described_class.deployer_for(options) }
+          .to raise_exception(Wordmove::UndefinedEnvironment)
+      end
+    end
+
     context "with ftp remote connection" do
       it "returns an instance of FTP deployer" do
         options[:environment] = "production"


### PR DESCRIPTION
Example of new error message 
========
Using movefile from `spec/fixtures/Movefile`

Error message before:
```
$ bin/wordmove pull -d -s -e staging
gems/wordmove/lib/wordmove/deployer/base.rb:16:in `deployer_for': undefined method `[]' for nil:NilClass (NoMethodError)
```

Error message after:
```
$ bin/wordmove pull -d -s -e staging
gems/wordmove/lib/wordmove/movefile.rb:59:in `environment': No environment found for "staging". Available Environments: remote (Wordmove::UndefinedEnvironment)
```

