### PR TITLE
WP CLI Configuration File Check

### DIFF
--- a/lib/wordmove/sql_adapter/wpcli.rb
+++ b/lib/wordmove/sql_adapter/wpcli.rb
@@ -40,7 +40,8 @@ module Wordmove
 
       def load_from_yml
         cli_config_path = File.join(local_path, "wp-cli.yml")
-        YAML.load_file(cli_config_path).with_indifferent_access["path"] if File.exist?(cli_config_path)
+        return unless File.exist?(cli_config_path)
+        YAML.load_file(cli_config_path).with_indifferent_access["path"]
       end
 
       def load_from_cli

--- a/lib/wordmove/sql_adapter/wpcli.rb
+++ b/lib/wordmove/sql_adapter/wpcli.rb
@@ -16,15 +16,15 @@ module Wordmove
         end
 
         [
-            "wp",
-            "search-replace",
-            cli_config_exists? ? "" : "--path=#{local_path}",
-            from,
-            to,
-            "--quiet",
-            "--skip-columns=guid",
-            "--all-tables",
-            "--allow-root",
+          "wp",
+          "search-replace",
+          cli_config_exists? ? "" : "--path=#{local_path}",
+          from,
+          to,
+          "--quiet",
+          "--skip-columns=guid",
+          "--all-tables",
+          "--allow-root"
         ].join(' ')
       end
 
@@ -33,6 +33,7 @@ module Wordmove
       def wp_in_path?
         system('which wp > /dev/null 2>&1')
       end
+
       def cli_config_exists?
         cli_config_path = File.join(local_path, "wp-cli.yml")
         File.exist?(cli_config_path)

--- a/lib/wordmove/sql_adapter/wpcli.rb
+++ b/lib/wordmove/sql_adapter/wpcli.rb
@@ -25,7 +25,7 @@ module Wordmove
           "--allow-root"
         ]
 
-        if cli_config_exists?
+        unless cli_config_exists?
           opts.unshift("--path=#{local_path}")
         end
 

--- a/lib/wordmove/sql_adapter/wpcli.rb
+++ b/lib/wordmove/sql_adapter/wpcli.rb
@@ -41,6 +41,7 @@ module Wordmove
       def load_from_yml
         cli_config_path = File.join(local_path, "wp-cli.yml")
         return unless File.exist?(cli_config_path)
+
         YAML.load_file(cli_config_path).with_indifferent_access["path"]
       end
 

--- a/lib/wordmove/sql_adapter/wpcli.rb
+++ b/lib/wordmove/sql_adapter/wpcli.rb
@@ -15,17 +15,21 @@ module Wordmove
           raise UnmetPeerDependencyError, "WP-CLI is not installed or not in your $PATH"
         end
 
+        opts =
         [
-          "wp",
-          "search-replace",
-          cli_config_exists? ? "" : "--path=#{local_path}",
           from,
           to,
           "--quiet",
           "--skip-columns=guid",
           "--all-tables",
           "--allow-root"
-        ].join(' ')
+        ]
+
+        if cli_config_exists?
+          opts.unshift("--path=#{local_path}")
+        end
+
+        "wp search-replace #{opts.join(' ')}"
       end
 
       private

--- a/lib/wordmove/sql_adapter/wpcli.rb
+++ b/lib/wordmove/sql_adapter/wpcli.rb
@@ -15,14 +15,24 @@ module Wordmove
           raise UnmetPeerDependencyError, "WP-CLI is not installed or not in your $PATH"
         end
 
-        "wp search-replace --path=#{local_path} #{from} #{to} --quiet "\
-        "--skip-columns=guid --all-tables --allow-root"
+        opts = [
+            "--quiet",
+            "--skip-columns=guid",
+            "--all-tables",
+            "--allow-root",
+            cli_config_exists? ? "" : "--path=#{local_path}"
+        ]
+        "wp search-replace #{from} #{to} #{opts.join(' ')}"
       end
 
       private
 
       def wp_in_path?
         system('which wp > /dev/null 2>&1')
+      end
+      def cli_config_exists?
+        cli_config_path = File.join(local_path, "wp-cli.yml")
+        File.exist?(cli_config_path)
       end
     end
   end

--- a/lib/wordmove/sql_adapter/wpcli.rb
+++ b/lib/wordmove/sql_adapter/wpcli.rb
@@ -16,7 +16,7 @@ module Wordmove
         end
 
         opts = [
-          "--path=#{get_cli_config_path}",
+          "--path=#{cli_config_path}",
           from,
           to,
           "--quiet",
@@ -34,15 +34,13 @@ module Wordmove
         system('which wp > /dev/null 2>&1')
       end
 
-      def get_cli_config_path
+      def cli_config_path
         load_from_yml || load_from_cli || local_path
       end
 
       def load_from_yml
         cli_config_path = File.join(local_path, "wp-cli.yml")
-        if File.exist?(cli_config_path)
-          YAML.load_file(cli_config_path).with_indifferent_access["path"]
-        end
+        YAML.load_file(cli_config_path).with_indifferent_access["path"] unless File.exist?(cli_config_path)
       end
 
       def load_from_cli

--- a/lib/wordmove/sql_adapter/wpcli.rb
+++ b/lib/wordmove/sql_adapter/wpcli.rb
@@ -15,8 +15,7 @@ module Wordmove
           raise UnmetPeerDependencyError, "WP-CLI is not installed or not in your $PATH"
         end
 
-        opts =
-        [
+        opts = [
           from,
           to,
           "--quiet",
@@ -25,9 +24,7 @@ module Wordmove
           "--allow-root"
         ]
 
-        unless cli_config_exists?
-          opts.unshift("--path=#{local_path}")
-        end
+        opts.unshift("--path=#{local_path}") unless cli_config_exists?
 
         "wp search-replace #{opts.join(' ')}"
       end

--- a/lib/wordmove/sql_adapter/wpcli.rb
+++ b/lib/wordmove/sql_adapter/wpcli.rb
@@ -40,7 +40,7 @@ module Wordmove
 
       def load_from_yml
         cli_config_path = File.join(local_path, "wp-cli.yml")
-        YAML.load_file(cli_config_path).with_indifferent_access["path"] unless File.exist?(cli_config_path)
+        YAML.load_file(cli_config_path).with_indifferent_access["path"] if File.exist?(cli_config_path)
       end
 
       def load_from_cli

--- a/lib/wordmove/sql_adapter/wpcli.rb
+++ b/lib/wordmove/sql_adapter/wpcli.rb
@@ -15,14 +15,17 @@ module Wordmove
           raise UnmetPeerDependencyError, "WP-CLI is not installed or not in your $PATH"
         end
 
-        opts = [
+        [
+            "wp",
+            "search-replace",
+            cli_config_exists? ? "" : "--path=#{local_path}",
+            from,
+            to,
             "--quiet",
             "--skip-columns=guid",
             "--all-tables",
             "--allow-root",
-            cli_config_exists? ? "" : "--path=#{local_path}"
-        ]
-        "wp search-replace #{from} #{to} #{opts.join(' ')}"
+        ].join(' ')
       end
 
       private

--- a/spec/fixtures/wp-cli.yml
+++ b/spec/fixtures/wp-cli.yml
@@ -1,0 +1,1 @@
+path: /path/to/steak

--- a/spec/sql_adapter/wpcli_spec.rb
+++ b/spec/sql_adapter/wpcli_spec.rb
@@ -12,7 +12,20 @@ describe Wordmove::SqlAdapter::Wpcli do
     )
   end
 
-  context "#command" do
+  context "#command_with_wp-cli.yml" do
+    before do
+      allow(adapter).to receive(:wp_in_path?).and_return(true)
+      allow(adapter).to receive(:cli_config_exists?).and_return(true)
+    end
+
+    it "returns the right command as a string" do
+      expect(adapter.command)
+        .to eq("wp search-replace sausage bacon --quiet "\
+               "--skip-columns=guid --all-tables --allow-root")
+    end
+  end
+
+  context "#command_without_wp-cli.yml" do
     before do
       allow(adapter).to receive(:wp_in_path?).and_return(true)
       allow(adapter).to receive(:cli_config_exists?).and_return(false)
@@ -20,7 +33,7 @@ describe Wordmove::SqlAdapter::Wpcli do
 
     it "returns the right command as a string" do
       expect(adapter.command)
-        .to eq("wp search-replace --path=/path/to/ham sausage bacon --quiet "\
+          .to eq("wp search-replace --path=/path/to/ham sausage bacon --quiet "\
                "--skip-columns=guid --all-tables --allow-root")
     end
   end

--- a/spec/sql_adapter/wpcli_spec.rb
+++ b/spec/sql_adapter/wpcli_spec.rb
@@ -34,7 +34,7 @@ describe Wordmove::SqlAdapter::Wpcli do
     it "returns the right command as a string" do
       expect(adapter.command)
         .to eq("wp search-replace --path=/path/to/ham sausage bacon --quiet "\
-           "--skip-columns=guid --all-tables --allow-root")
+               "--skip-columns=guid --all-tables --allow-root")
     end
   end
 end

--- a/spec/sql_adapter/wpcli_spec.rb
+++ b/spec/sql_adapter/wpcli_spec.rb
@@ -15,20 +15,34 @@ describe Wordmove::SqlAdapter::Wpcli do
   context "#command_with_wp-cli.yml" do
     before do
       allow(adapter).to receive(:wp_in_path?).and_return(true)
-      allow(adapter).to receive(:cli_config_exists?).and_return(true)
+      allow(File).to receive(:exist?).and_return(true)
+      allow(YAML).to receive(:load_file).and_return(path: "/path/to/steak")
     end
 
     it "returns the right command as a string" do
       expect(adapter.command)
-        .to eq("wp search-replace sausage bacon --quiet "\
+        .to eq("wp search-replace --path=/path/to/steak sausage bacon --quiet "\
                "--skip-columns=guid --all-tables --allow-root")
     end
   end
 
-  context "#command_without_wp-cli.yml" do
+  context "#command_with_params" do
     before do
       allow(adapter).to receive(:wp_in_path?).and_return(true)
-      allow(adapter).to receive(:cli_config_exists?).and_return(false)
+      allow(adapter).to receive(:`).and_return("{\"path\":{\"current\":\"\/path\/to\/pudding\"}}")
+    end
+
+    it "returns the right command as a string" do
+      expect(adapter.command)
+        .to eq("wp search-replace --path=/path/to/pudding sausage bacon --quiet "\
+               "--skip-columns=guid --all-tables --allow-root")
+    end
+  end
+
+  context "#command_with_no_configured_path" do
+    before do
+      allow(adapter).to receive(:wp_in_path?).and_return(true)
+      allow(File).to receive(:exist?).and_return(false)
     end
 
     it "returns the right command as a string" do

--- a/spec/sql_adapter/wpcli_spec.rb
+++ b/spec/sql_adapter/wpcli_spec.rb
@@ -33,8 +33,8 @@ describe Wordmove::SqlAdapter::Wpcli do
 
     it "returns the right command as a string" do
       expect(adapter.command)
-          .to eq("wp search-replace --path=/path/to/ham sausage bacon --quiet "\
-               "--skip-columns=guid --all-tables --allow-root")
+        .to eq("wp search-replace --path=/path/to/ham sausage bacon --quiet "\
+           "--skip-columns=guid --all-tables --allow-root")
     end
   end
 end

--- a/spec/sql_adapter/wpcli_spec.rb
+++ b/spec/sql_adapter/wpcli_spec.rb
@@ -43,6 +43,7 @@ describe Wordmove::SqlAdapter::Wpcli do
     before do
       allow(adapter).to receive(:wp_in_path?).and_return(true)
       allow(File).to receive(:exist?).and_return(false)
+      allow(adapter).to receive(:`).and_return("{}")
     end
 
     it "returns the right command as a string" do

--- a/spec/sql_adapter/wpcli_spec.rb
+++ b/spec/sql_adapter/wpcli_spec.rb
@@ -15,6 +15,7 @@ describe Wordmove::SqlAdapter::Wpcli do
   context "#command" do
     before do
       allow(adapter).to receive(:wp_in_path?).and_return(true)
+      allow(adapter).to receive(:cli_config_exists?).and_return(false)
     end
 
     it "returns the right command as a string" do

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -1,4 +1,12 @@
 module FixtureHelpers
+  def fixture_folder_path
+    File.join(__dir__, '..', 'fixtures')
+  end
+
+  def fixture_folder_root_relative_path
+    File.join('spec', 'fixtures')
+  end
+
   def fixture_path_for(filename)
     File.join(__dir__, '..', 'fixtures', filename)
   end


### PR DESCRIPTION
This is a possible approach to handling issues #590 and #591 concerning how the WP CLI path option is handled when `wordpress_path` is pointed to a non-standard project root (ie: Bedrock)

The idea here is that --path is only added when a wp-cli.yml file does not exist. In the case that one _does_ exist, then WP CLI will fall back on the configuration there to allow the user to specify the path to Wordpress.

An extra test case has also been added to account for both scenarios.

I don't actually know Ruby, so I have this in draft status in case I'm doing anything that you don't agree with.

The one change here that might be debatable is using an array join to create the WP CLI command. I do this instead of standard string concatenation to handle whitespace a little more predictably and possibly improve readability. 