### PR TITLE
Adds a VVV utility provisioner

### DIFF
--- a/bin/provision.sh
+++ b/bin/provision.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# VVV Install script
+
+# Rubygems update
+if [ $(gem -v|grep '^2.') ]; then
+	echo "gem installed"
+else
+	apt-get install -y ruby-dev
+	echo "ruby-dev installed"
+	echo "gem not installed"
+	gem install rubygems-update
+	update_rubygems
+fi
+
+# wordmove install
+wordmove_install="$(gem list wordmove -i)"
+if [ "$wordmove_install" = true ]; then
+  echo "wordmove installed"
+else
+  echo "wordmove not installed"
+  gem install wordmove
+
+  wordmove_path="$(gem which wordmove | sed -s 's/.rb/\/deployer\/base.rb/')"
+  if [  "$(grep yaml $wordmove_path)" ]; then
+    echo "can require yaml"
+  else
+    echo "can't require yaml"
+    echo "set require yaml"
+
+    sed -i "7i require\ \'yaml\'" $wordmove_path
+
+    echo "can require yaml"
+
+  fi
+fi


### PR DESCRIPTION
Related to #598

To test, modify a VVV config with the following:

```yaml
utility-sources:
  wordmove:
    repo: https://github.com/tomjn/wordmove.git
    branch: patch-1
```

Then add it to the list of utilities to install, e.g.

```yaml
utilities:
  core: # The core VVV utility
    - tls-ca # HTTPS SSL/TLS certificates
    - phpmyadmin # Web based database client
  wordmove:
    - bin
```

Once merged, the `utility-sources` will change to:

```yaml
utility-sources:
  wordmove:
    repo: https://github.com/welaika/wordmove.git
```

Most of this PRs description can be copied as is for the new wiki docs