### PR TITLE
Fix mu-plugins key in mu_plugins. Fixes #619

### DIFF
--- a/lib/wordmove/assets/wordmove_schema_remote.yml
+++ b/lib/wordmove/assets/wordmove_schema_remote.yml
@@ -162,7 +162,7 @@ mapping:
             type: bool
           uploads:
             type: bool
-          mu-plugins:
+          mu_plugins:
             type: bool
       push:
         type: map
@@ -177,5 +177,5 @@ mapping:
             type: bool
           uploads:
             type: bool
-          mu-plugins:
+          mu_plugins:
             type: bool


### PR DESCRIPTION
The documentation was also wrong. It is now fixed https://github.com/welaika/wordmove/wiki/movefile.yml-configurations-explained#forbid