### PR TITLE
Update generator to correct key notation for mu_plugins

### DIFF
--- a/lib/wordmove/generators/movefile.yml
+++ b/lib/wordmove/generators/movefile.yml
@@ -93,14 +93,14 @@ production:
   #     themes: false
   #     languages: false
   #     uploads: false
-  #     mu-plugins: false
+  #     mu_plugins: false
   #   pull:
   #     db: false
   #     plugins: false
   #     themes: false
   #     languages: false
   #     uploads: false
-  #     mu-plugins: false
+  #     mu_plugins: false
 
 # staging: # multiple environments can be specified
 #   [...]


### PR DESCRIPTION
In version 5.2.2 doctor was adjusted (https://github.com/welaika/wordmove/issues/619) to check for the new key notation `mu_plugins`.  However the generator still comes with the old notation `mu-plugins`, resulting in the now correct error:
> error | [/forbid/push/mu-plugins] key 'mu-plugins:' is undefined.

-----

This pull requests updates the key used in the generator template to `mu_plugins`.